### PR TITLE
Add final operation method to help PCEX backend

### DIFF
--- a/cf_cell_methods/pcex_helpers.py
+++ b/cf_cell_methods/pcex_helpers.py
@@ -1,0 +1,29 @@
+# The functions in this file are helpers for the PCEX backend.
+
+from cf_cell_methods import parse
+# Used by the climate explorer backend to filter datasets
+# PCEX cares about what the LAST cell method is, as this records the type
+# of statistical data used the dataset. Generally users selecting a dataset
+# to view are offered the choice of all datasets representing climatological
+# means and ensemble means, for whom the last cell method will be a mean 
+# calculation. 
+# Datasets representing other statistical calculations - percentiles and 
+# standards deviations - are present in the database to be used to provide
+# additional context to the dataset selected by the user. They are handled
+# differently by the PCEX backend.
+# Some example final cell methods:
+#     * time: mean over days (a climatological mean - user can view this)
+#     * time: standard_deviation over days (a climatological SD - used for context)
+#     * models: mean (PCIC12 climatologies - user can view this)
+#     * models: percentile[n] (hydrology percentile data - used for context)
+# Since PCEX treats means over model ensembles and means over time identically, 
+# all the backend needs to know is the last cell method - "mean", "standard_deviation",
+# "percentile", or other / None. 
+def final_operation(cell_method):
+    try:
+        cm = parse(cell_method)
+        method_str = cm[-1].method.name
+        #strip percentile bonus information if present
+        return method_str.split("[")[0]
+    except: # PCEX has noisy data, handle unparsable
+        return None

--- a/tests/test_pcex_helpers.py
+++ b/tests/test_pcex_helpers.py
@@ -1,0 +1,19 @@
+import pytest
+from cf_cell_methods import parse
+from cf_cell_methods.pcex_helpers import final_operation
+
+@pytest.mark.parametrize(
+    "cell_method_str, expected",
+    (
+        ("time: mean within years time: median over years", "median"),
+        ("unspecified", None),
+        ("time: max within days time: mean over days", "mean"),
+        ("time: mean (interval: 20minutes)", "mean"),
+        ("time: sum within days time: maximum within months", "maximum"),
+        ("time: minimum within days time: count within years where < 0 C", None),
+        ("time: mean within days time: maximum over days models: percentile[5]", "percentile"),
+        ("area: mean", "mean")
+    )
+)
+def test_final_operation(cell_method_str, expected):
+    assert final_operation(cell_method_str) == expected


### PR DESCRIPTION
This branch adds a simple method that will allow the PCEX backend to use this package for its dataset-filtering needs rather than munging cell methods itself.

I suspect @rod-glover will have suggestions on more elegant ways to achieve the same result; this PR is more a discussion and a description of the problem space than anything else.

The PCEX backend needs to use this cell method parser to distinguish among three types of dataset, each of which can be requested separately via its API via a parameter. The three types of dataset represent different climatological statistics.

**Type 1: Standard Deviation data (parameter: standard_deviation)**
These are climatological standard deviations. They have correct cell methods. At present, the following cell methods are in this category:
* `time: mean time: standard_deviation over days`
* `time: maximum time: standard_deviation over days`
* `time: minimum time: standard_deviation over days`
though of course we may add other standard deviation data someday.

**Type 2: percentile data (parameter: percentile)**
These are percentiles over ensembles of models. This data is not yet in the database, but will have correct cell methods when it is. Their cell_methods are expected to be
* `time: mean within days time: max over days time: mean over days models: percentile[N]` (for various N)
though of course we may add other percentile data someday.

**Type 3: Everything else (parameter: mean)**
All other files available to PCEX are climatological means<sup>1</sup>.  Unfortunately, many of these files have unreliable cell_methods; at this point in time we cannot rely on parsing their cell methods to determine they are climatological means, only the process of elimination.
* `[something] time: mean over days` (made by `generate_climos`, generally correct-ish)
* `[something] time:mean over days models: mean` (PCIC12 data, occasionally, notable because it has an operation AFTER the climatological averaging but still counts as a climatological mean)
* `[something unparsable]`
* `[something parsable but wrong]`

The easiest way to distinguish these types of files given the unreliability of cell_methods for Type 3 is to check the operation of the last method. It is either `standard_deviation` (type 1), `percentile[N]` (type 2) `mean` (type 3), anything else (type 3), or the cell method is unparsable (also type 3). Accordingly, I have added a function that just returns the operation string of the final method for the PCEX backend's use.

I'm open to other approaches. 

We could make a predicate for each type, in the style of the functions in semantics.py, but depending on how we wrote them, we might have to update the predicates if we got more files added to that type. (Plus we'd maybe want several different predicates for type three to cover all cases?)

Alternately, we could have the backend do the parsing if we preferred. Currently it is using a fairly fragile regex, but it could use the tools this package provides instead. 

There are probably other options.

Thoughts on the best approach, @rod-glover ?

-------------------

<sup>1</sup> With the exception of the physical geography files, which are not climatological statistics, used by the `/watershed` API. Nobody should be using any other API with them so they don't really enter into this conversations. They are distinguishable by having all their cell methods over `area:` instead of time. They have no time component.